### PR TITLE
add hint to add python path to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Install ruff first:
 
 ```bash
 pip install ruff
+
+# You may have to set your path to include ruff's binary location:
+export PATH=$PATH:$HOME/.local/bin
+
+# Or do so permanently in bash
+echo "export PATH=$PATH:$HOME/.local/bin" >> .bashrc
 ```
 
 Clone this repository into your workspace and build it:


### PR DESCRIPTION
Add an extra hint to the documentation about python path when pip install ruff